### PR TITLE
Rewrote Nt4Client to work with .NET 8.0 (doesn't use outdated package "WebSocketSharp-netstandard")

### DIFF
--- a/NetworkTablesSharp.csproj
+++ b/NetworkTablesSharp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>NetworkTablesSharp</RootNamespace>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -19,11 +19,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MessagePack" Version="3.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
+		<PackageReference Include="MessagePack" Version="2.*" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.*" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="LICENSE">
       <Pack>True</Pack>

--- a/Nt4Source.cs
+++ b/Nt4Source.cs
@@ -54,6 +54,13 @@ namespace NetworkTablesSharp
             _queuedPublishes.TryAdd(topic, (type, properties));
         }
 
+
+        public void PublishTopic(string tablePath, string key, string type, Dictionary<string, object>? properties = null)
+        {
+            GetTable(tablePath).PublishTopic(key, type, properties);
+        }
+
+
         /// <summary>
         /// Publish a value to a topic
         /// </summary>
@@ -65,6 +72,11 @@ namespace NetworkTablesSharp
             {
                 Client.PublishValue(topic, value);
             }
+        }
+
+        public void PublishValue(string tablePath, string key, object value)
+        {
+            GetTable(tablePath).PublishValue(key, value);
         }
 
         /// <summary>
@@ -82,6 +94,11 @@ namespace NetworkTablesSharp
                 Client.Subscribe(topic, period, all, topicsOnly, prefix);
             }
             _queuedSubscribes.TryAdd(topic, new Nt4SubscriptionOptions(period, all, topicsOnly, prefix));
+        }
+
+        public void Subscribe(string tablePath, string key, double period = 0.1, bool all = false, bool topicsOnly = false, bool prefix = false)
+        {
+            GetTable(tablePath).Subscribe(key, period, all, topicsOnly, prefix);
         }
 
         /// <summary>
@@ -113,6 +130,11 @@ namespace NetworkTablesSharp
             }
 
             return default;
+        }
+
+        public Nt4Table GetTable(string tablePath)
+        {
+            return new Nt4Table(this, tablePath);
         }
 
         /// <summary>

--- a/Nt4Source.cs
+++ b/Nt4Source.cs
@@ -89,7 +89,7 @@ namespace NetworkTablesSharp
         /// </summary>
         /// <param name="key">The topic to get the value of</param>
         /// <returns>The latest value of the topic, or default if it doesn't exist</returns>
-        public T GetValue<T>(string key)
+        public T? GetValue<T>(string key)
         {
             if (_values.TryGetValue(key, out var value))
             {
@@ -105,7 +105,7 @@ namespace NetworkTablesSharp
         /// <param name="key">The topic to get the value of</param>
         /// <param name="timestamp">The timestamp to get the value at</param>
         /// <returns>The most recent value before or at the given timestamp, or default if it doesn't exist</returns>
-        public T GetValue<T>(string key, long timestamp)
+        public T? GetValue<T>(string key, long timestamp)
         {
             if (_values.TryGetValue(key, out var value))
             {

--- a/Nt4Table.cs
+++ b/Nt4Table.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace NetworkTablesSharp
+{
+    /// <summary>
+    /// Represents a logical "table" (path prefix) in the NT4 topic space.
+    /// </summary>
+    public sealed class Nt4Table
+    {
+        private readonly Nt4Source _source;
+        private readonly string _tablePath; // normalized: starts with '/', no trailing '/'
+
+        internal Nt4Table(Nt4Source source, string tablePath)
+        {
+            _source = source;
+            _tablePath = NormalizeTablePath(tablePath);
+        }
+
+        private static string NormalizeTablePath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path)) return string.Empty;
+            var p = path.Replace('\\', '/').Trim();
+            if (!p.StartsWith("/")) p = "/" + p;
+            // remove trailing slash (except if root "/")
+            if (p.Length > 1 && p.EndsWith("/")) p = p.TrimEnd('/');
+            return p;
+        }
+
+        private string FullKey(string key)
+        {
+            if (string.IsNullOrWhiteSpace(key)) throw new ArgumentException("Key cannot be empty.", nameof(key));
+            var k = key.Replace('\\', '/');
+            if (k.StartsWith("/")) k = k.TrimStart('/');
+            // root table "" behaves like global
+            return string.IsNullOrEmpty(_tablePath) ? "/" + k : _tablePath + "/" + k;
+        }
+
+        /// <summary>
+        /// Publish a topic (create it with type and optional properties) within this table.
+        /// </summary>
+        public void PublishTopic(string key, string type, Dictionary<string, object>? properties = null)
+        {
+            _source.Client.PublishTopic(FullKey(key), type, properties ?? new Dictionary<string, object>());
+        }
+
+        /// <summary>
+        /// Publish a value to a topic in this table.
+        /// </summary>
+        public void PublishValue(string key, object value)
+        {
+            _source.Client.PublishValue(FullKey(key), value);
+        }
+
+        /// <summary>
+        /// Subscribe to one key in this table.
+        /// </summary>
+        public int Subscribe(string key, double period = 0.1, bool all = false, bool topicsOnly = false, bool prefix = false)
+        {
+            return _source.Client.Subscribe(FullKey(key), period, all, topicsOnly, prefix);
+        }
+
+        /// <summary>
+        /// Subscribe to many keys in this table (array of keys relative to the table).
+        /// </summary>
+        public int Subscribe(string[] keys, double period = 0.1, bool all = false, bool topicsOnly = false, bool prefix = false)
+        {
+            var full = new string[keys.Length];
+            for (int i = 0; i < keys.Length; i++) full[i] = FullKey(keys[i]);
+            return _source.Client.Subscribe(full, period, all, topicsOnly, prefix);
+        }
+
+        /// <summary>
+        /// Subscribe using explicit options.
+        /// </summary>
+        public int Subscribe(string key, Nt4SubscriptionOptions opts)
+        {
+            return _source.Client.Subscribe(FullKey(key), opts);
+        }
+
+        /// <summary>
+        /// Convenience read: get the latest value typed from the local cache in Nt4Source.
+        /// </summary>
+        public T? GetValue<T>(string key)
+        {
+            return _source.GetValue<T>(FullKey(key));
+        }
+
+        /// <summary>
+        /// Convenience read at a timestamp from the local cache in Nt4Source.
+        /// </summary>
+        public T? GetValue<T>(string key, long timestampUs)
+        {
+            return _source.GetValue<T>(FullKey(key), timestampUs);
+        }
+    }
+}

--- a/TopicValue.cs
+++ b/TopicValue.cs
@@ -18,7 +18,7 @@ namespace NetworkTablesSharp
             return _latestValue;
         }
         
-        public T GetValue(long timestamp)
+        public T? GetValue(long timestamp)
         {
             if (_timestampedValues.ContainsKey(timestamp))
             {


### PR DESCRIPTION
**This code was tested with a .NET 8.0 Console app, I didn't test it with Unity.**


Also added support for network tables "Table" for example:

```C#
m_tableName = "Vision";
Source.Subscribe(m_tableName, "robot_position_x");
```

<img width="473" height="436" alt="image" src="https://github.com/user-attachments/assets/4b5acc43-e0d8-40e3-a0c6-699405bdb46b" />

